### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/app/api/ai-roast/route.ts
+++ b/src/app/api/ai-roast/route.ts
@@ -25,11 +25,17 @@ function getClientIp(req: NextRequest): string {
 
 function isAllowedReferer(req: NextRequest): boolean {
   const referer = req.headers.get('referer') ?? '';
-  return (
-    referer.startsWith('http://localhost') ||
-    referer.startsWith('https://localhost') ||
-    referer.startsWith('https://snupai.me')
-  );
+  try {
+    const url = new URL(referer);
+    const allowedHostnames = [
+      'localhost',
+      'snupai.me',
+    ];
+    return allowedHostnames.includes(url.hostname);
+  } catch {
+    // If referer is not a valid URL, reject
+    return false;
+  }
 }
 
 function buildCacheHeaders(ttlSeconds: number): HeadersInit {


### PR DESCRIPTION
Potential fix for [https://github.com/Snupai/snupai-site/security/code-scanning/1](https://github.com/Snupai/snupai-site/security/code-scanning/1)

To fix the problem, the referer URL should be parsed, and its `hostname` property compared against an explicit whitelist of allowed hostnames. For subdomain support, the allowed hostnames should be clearly listed in an array, e.g., `['snupai.me', 'www.snupai.me']`. This ensures only referers from the correct hosts are accepted. Specifically, you should replace the string `referer.startsWith('https://snupai.me')` logic in the `isAllowedReferer` function (lines 26-33) with code that parses the referer URL using the built-in `URL` class and checks the `hostname` against an array of allowed hostnames.

You will need to add an import for `URL` if not already available (globally available in Node.js and modern runtimes), and modify the `isAllowedReferer` function to use parsed referer URLs for host validation. Only edit shown code in `src/app/api/ai-roast/route.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces substring-based referer checks with URL-parsed hostname validation against an explicit allowlist, rejecting invalid URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80953e6c181abf88249a9ae49a3a3afd91352c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->